### PR TITLE
fix those configure complaints about test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,13 +48,13 @@ AC_ARG_WITH([allegro4],
 AC_ARG_WITH([allegro],
         [AS_HELP_STRING([--without-allegro], [build the game without allegro libraries])], [], [with_allegro=yes])
 
-if test x"$with_allegro4" = x"no" -a x"$with_allegro5" = x"no" -a test x"$with_allegro" = x"yes" ; then
+if test x"$with_allegro4" = x"no" -a x"$with_allegro5" = x"no" -a x"$with_allegro" = x"yes" ; then
         AC_MSG_ERROR(use --with-allegro5 or --with-allegro4 or --without-allegro)
-elif test x"$with_allegro4" = x"no" -a x"$with_allegro5" = x"yes" -a test x"$with_allegro" = x"yes" ; then
+elif test x"$with_allegro4" = x"no" -a x"$with_allegro5" = x"yes" -a x"$with_allegro" = x"yes" ; then
         AC_MSG_NOTICE(building with allegro5)
-elif test x"$with_allegro4" = x"yes" -a x"$with_allegro5" = x"no" -a test x"$with_allegro" = x"yes" ; then
+elif test x"$with_allegro4" = x"yes" -a x"$with_allegro5" = x"no" -a x"$with_allegro" = x"yes" ; then
         AC_MSG_NOTICE(building with allegro4)
-elif test x"$with_allegro4" = x"yes" -a x"$with_allegro5" = x"yes" -a test x"$with_allegro" = x"yes" ; then
+elif test x"$with_allegro4" = x"yes" -a x"$with_allegro5" = x"yes" -a x"$with_allegro" = x"yes" ; then
         AC_MSG_ERROR(--with-allegro5 and --with-allegro4 are mutually exclusive)
 elif test x"$with_allegro" = x"no" ; then
         AC_MSG_NOTICE(building without allegro libraries)


### PR DESCRIPTION
Before
```
checking for tinyxml2.h... yes
./configure: line 17796: test: too many arguments
./configure: line 17798: test: too many arguments
./configure: line 17801: test: too many arguments
./configure: line 17804: test: too many arguments
checking for allegro5/allegro.h... yes
```
After
```
checking for tinyxml2.h... yes
checking for allegro5/allegro.h... yes
```