### PR TITLE
Add guard for code that should only be allegro4

### DIFF
--- a/src/WrappersAllegro.cpp
+++ b/src/WrappersAllegro.cpp
@@ -1743,6 +1743,7 @@ void textOut( const std::string& text, int x, int y, AllegroColor color )
 #endif
 }
 
+#if defined( USE_ALLEGRO4 ) && USE_ALLEGRO4
 std::string allegroAudioDriverCodeToName( int code )
 {
         if ( code == DIGI_AUTODETECT ) return "DIGI_AUTODETECT" ;
@@ -1757,6 +1758,7 @@ std::string allegroAudioDriverCodeToName( int code )
 
         return "unknown" ;
 }
+#endif
 
 void initAudio()
 {


### PR DESCRIPTION
As commented earlier. This enable the code to compile and work when using allegro5.