### PR TITLE
Replace the .in header file by direct setting of variables in CPPFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -254,7 +254,6 @@ AC_SUBST([allegro_LIBS])
 AC_CONFIG_FILES([
         Makefile
         source/Makefile
-        source/path_prefix.h
         gamedata/Makefile
         gamedata/gfx/Makefile
         gamedata/gfx.2009/Makefile

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -23,7 +23,8 @@ if DARWIN
     AM_CXXFLAGS += -DDARWIN=1
 endif
 
-headoverheels_CPPFLAGS = -Iactivities -Ibehaviors -Igui -Iguiactions -DBinDirFromConfigure=\"$(bindir)\" -DDataDirFromConfigure=\"$(datadir)\"
+headoverheels_CPPFLAGS =  -Iactivities -Ibehaviors -Igui -Iguiactions
+headoverheels_CPPFLAGS += -DBinDirFromConfigure=\"$(bindir)\" -DDataDirFromConfigure=\"$(datadir)\"
 headoverheels_CPPFLAGS += $(zlib_HEADERS) $(libpng_HEADERS) $(ogg_HEADERS) $(vorbis_HEADERS) $(tinyxml2_HEADERS) $(allegro_HEADERS)
 headoverheels_CPPFLAGS += $(AM_CPPFLAGS)
 

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -23,7 +23,7 @@ if DARWIN
     AM_CXXFLAGS += -DDARWIN=1
 endif
 
-headoverheels_CPPFLAGS = -Iactivities -Ibehaviors -Igui -Iguiactions
+headoverheels_CPPFLAGS = -Iactivities -Ibehaviors -Igui -Iguiactions -DBinDirFromConfigure=\"$(bindir)\" -DDataDirFromConfigure=\"$(datadir)\"
 headoverheels_CPPFLAGS += $(zlib_HEADERS) $(libpng_HEADERS) $(ogg_HEADERS) $(vorbis_HEADERS) $(tinyxml2_HEADERS) $(allegro_HEADERS)
 headoverheels_CPPFLAGS += $(AM_CPPFLAGS)
 

--- a/source/ospaths.cpp
+++ b/source/ospaths.cpp
@@ -2,8 +2,6 @@
 #include "ospaths.hpp"
 #include "util.hpp"
 
-#include "path_prefix.h"
-
 #include <algorithm>
 
 #include <unistd.h> // getcwd
@@ -82,7 +80,7 @@ void setPathToGame ( const char * pathToGame )
                 FullPathToGame = "/bin/headoverheels" ;         /* hard-coded */
 #else
                 /* more sophiscated logic */ // at least than = "/usr/bin/headoverheels"
-                FullPathToGame = std::string( ThatPrefixFromConfigure ) + "/bin/headoverheels" ;
+                FullPathToGame = BinDirFromConfigure + ospaths::pathSeparator () + "headoverheels" ;
                 /* and those who wish a custom name for the game's binary
                    may sophiscate it further more */
 #endif
@@ -182,8 +180,7 @@ std::string sharePath ()
                         SharePath += "/share/headoverheels/";
                 }
         #else
-                SharePath = cpath.substr( 0, cpath.length() - filename.length() - ( 1 + containername.length() ) );
-                SharePath += "share" + ospaths::pathSeparator () + "headoverheels" + ospaths::pathSeparator () ;
+                SharePath = DataDirFromConfigure + ospaths::pathSeparator () + "headoverheels" + ospaths::pathSeparator () ;
         #endif
 
                 fprintf ( stdout, "SharePath is \"%s\"\n", SharePath.c_str () );

--- a/source/ospaths.cpp
+++ b/source/ospaths.cpp
@@ -79,10 +79,9 @@ void setPathToGame ( const char * pathToGame )
 #if defined ( __CYGWIN__ )
                 FullPathToGame = "/bin/headoverheels" ;         /* hard-coded */
 #else
-                /* more sophiscated logic */ // at least than = "/usr/bin/headoverheels"
                 FullPathToGame = BinDirFromConfigure + ospaths::pathSeparator () + "headoverheels" ;
-                /* and those who wish a custom name for the game's binary
-                   may sophiscate it further more */
+                /* customizing the name of the game's binary
+                   will need more exquisite logic */
 #endif
         }
 
@@ -151,36 +150,23 @@ std::string sharePath ()
 {
         if ( SharePath.empty () )
         {
-                std::string cpath = FullPathToGame ;
-                std::string filename = nameFromPath( cpath ) ;
+                SharePath = DataDirFromConfigure + ospaths::pathSeparator () + "headoverheels" + ospaths::pathSeparator () ;
 
         #if defined ( __APPLE__ ) && defined ( __MACH__ )
-                /* when binary is inside application bundle
-                   get_executable_name gives something like
-                   /Applications/Games/Head over Heels.app
-                   and nameFromPath in its turn gives
-                   Head over Heels.app */
+                std::string fullpath = FullPathToGame ;
                 bool inBundle = false;
-                const char* lastdot = std::strrchr ( filename.c_str() , '.' );
+
+                /* when the binary is inside an application bundle
+                   fullpath is something like /Applications/Games/Head over Heels.app
+                   and nameFromPath gives Head over Heels.app
+                */
+                const char* lastdot = std::strrchr ( nameFromPath( fullpath ).c_str () , '.' );
                 if ( lastdot != NULL && strlen( lastdot ) == 4 )
                         if ( lastdot[ 1 ] == 'a' && lastdot[ 2 ] == 'p' && lastdot[ 3 ] == 'p' )
                                 inBundle = true;
-        #endif
 
-                std::string container = cpath.substr( 0, cpath.length() - filename.length() - 1 );
-                std::string containername = nameFromPath( container ) ;
-
-        #if defined ( __APPLE__ ) && defined ( __MACH__ )
-                if ( inBundle ) {
-                        SharePath = cpath ;
-                        SharePath += "/Contents/Resources/";
-                } else {
-                        /* not in bundle? okay so go the linux way */
-                        SharePath = cpath.substr( 0, cpath.length() - 1 - containername.length() - 1 - filename.length() );
-                        SharePath += "/share/headoverheels/";
-                }
-        #else
-                SharePath = DataDirFromConfigure + ospaths::pathSeparator () + "headoverheels" + ospaths::pathSeparator () ;
+                if ( inBundle )
+                        SharePath = fullpath + "/Contents/Resources/" ;
         #endif
 
                 fprintf ( stdout, "SharePath is \"%s\"\n", SharePath.c_str () );

--- a/source/path_prefix.h.in
+++ b/source/path_prefix.h.in
@@ -1,1 +1,0 @@
-#define ThatPrefixFromConfigure "@prefix@"


### PR DESCRIPTION
The logic here is to use macro definitions in CPP flags at build time rather than setting them in a `.h.in` file. The reason for this is mainly that `prefix`, `bindir`, `datadir` and other variables are defined in ways where you expect them to be used by scripts rather than directly in source files.
In my first attempt to use `bindir` rather than `prefix` in a `.h.in` file the value was set to
```
Path=${prefix}/bin
```
Which was unsuitable and why I switched to using `prefix` and introducing the `bin` manually. No such issues when setting it from `Makefile.am` all the substitution will be done at calling time.
 
Of course, config.h.in` files do exists but they usually limit themselves to turning on or off some features, they are not usually meant to transmit a configuration directory wholesale.