### PR TITLE
fix rooms in map.xml disagree whatbis above/below

### DIFF
--- a/gamedata/map/map.xml
+++ b/gamedata/map/map.xml
@@ -896,7 +896,7 @@
 
     <room file="penitentiary31.xml">
         <below>penitentiary32.xml</below>
-        <above>penitentiary30.xml</above>
+        <above>penitentiary29.xml</above>
     </room>
 
     <room file="penitentiary32.xml">


### PR DESCRIPTION
map.xml had penitentiary31 below penitentiary29, but pen30 above pen31.

Fix this inconsistency so that rooms agree who is above/below each other.

Note - I don't think it is possible to jump out of this room, so it may not matter in gameplay.